### PR TITLE
Fix on macos

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-            - macOS-latest
+          - macOS-latest
             # - windows-latest
         arch:
           - x64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-            # - macOS-latest
+            - macOS-latest
             # - windows-latest
         arch:
           - x64

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -12,7 +12,7 @@ os = "linux"
 arch = "x86_64"
 git-tree-sha1 = "b32e2cfada1778f9f65843685dffcb62687d0054"
 lazy = true
-os = "osx"
+os = "macos"
 
     [[onnxruntime_cpu.download]]
     sha256 = "41f7e8f3039f00be41fa9e8fba881e3698822d9b70f8a80d4a8d6728b7a4b45b"

--- a/src/capi.jl
+++ b/src/capi.jl
@@ -13,7 +13,7 @@ using Libdl
 using CEnum: @cenum
 using ArgCheck
 using LazyArtifacts
-using Pkg.Artifacts: @artifact_str, artifact_path
+using Pkg.Artifacts: artifact_path, ensure_artifact_installed, find_artifacts_toml
 
 const LIB_CPU  = Ref(C_NULL)
 const LIB_CUDA = Ref(C_NULL)
@@ -41,17 +41,19 @@ end
 function make_lib!(execution_provider)
     @argcheck execution_provider in EXECUTION_PROVIDERS
     root = if execution_provider === :cpu
-        let path
-            cpu_hash = artifact_hash("onnxruntime_cpu", joinpath(@__DIR__, "Artifacts.toml"))
-            path = artifact_path(cpu_hash)
+        let 
+            cpu_hash = artifact_hash("onnxruntime_cpu", find_artifacts_toml(joinpath(@__DIR__ , "ONNXRunTime.jl")))
+            ensure_artifact_installed("onnxruntime_cpu", find_artifacts_toml(joinpath(@__DIR__ , "ONNXRunTime.jl")))
+            artifact_path(cpu_hash)
         end
     elseif execution_provider === :cuda
-        let path
-            gpu_hash = artifact_hash("onnxruntime_gpu", joinpath(@__DIR__, "Artifacts.toml"))
+        let 
+            gpu_hash = artifact_hash("onnxruntime_gpu", find_artifacts_toml(joinpath(@__DIR__ , "ONNXRunTime.jl")))
             if gpu_hash === nothing
                 error("Unsupported backend on current system")
             end
-            path = artifact_path(gpu_hash)
+            ensure_artifact_installed("onnxruntime_gpu", find_artifacts_toml(joinpath(@__DIR__ , "ONNXRunTime.jl")))
+            artifact_path(gpu_hash)
         end
     else
         error("Unknown execution_provider $(repr(execution_provider))")


### PR DESCRIPTION
Fixes #9, the artifact path detection was changed because onnxruntime doesn't have a gpu runtime on macos and it was giving errors on precompile.