### PR TITLE
added check to prevent CUDA driver activation if CUDA is not functional

### DIFF
--- a/src/ONNXRunTime.jl
+++ b/src/ONNXRunTime.jl
@@ -15,7 +15,9 @@ include("capi.jl")
 include("highlevel.jl")
 
 function __init__()
-    @require CUDA="052768ef-5323-5732-b1bb-66c8b64840ba" include("cuda.jl")
+    @require CUDA="052768ef-5323-5732-b1bb-66c8b64840ba" begin
+        CUDA.functional() && include("cuda.jl")
+    end
 end
 
 end #module


### PR DESCRIPTION
This check is required when CUDA is imported somewhere but actual drivers are unavailable. Without that check, the package fails while attempting to CUDA libraries load.