### PR TITLE
Support CUDA provider options.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ONNXRunTime"
 uuid = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ julia> import CUDA, cuDNN
 julia> ORT.load_inference(path, execution_provider=:cuda)
 ```
 
+CUDA provider options can be specified
+```
+julia> ORT.load_inference(path, execution_provider=:cuda,
+                          provider_options=(;cudnn_conv_algo_search=:HEURISTIC))
+```
+
 Memory allocated by a model is eventually automatically released after
 it goes out of scope, when the model object is deleted by the garbage
 collector. It can also be immediately released with `release(model)`.


### PR DESCRIPTION
This PR adds the possibility to specify provider options in `load_inference`.

Of particular interest is the CUDA provider option `cudnn_conv_algo_search`. The default `EXHAUSTIVE` option is, although fastest, numerically somewhat unreliable. On newer GPUs it can cause Float32 convolution layers to produce results which vary with like 1000 eps between different sessions. For certain applications it's therefore valuable to be able to choose the (at least empirically) more stable `DEFAULT` and `HEURISTIC` options.
