### PR TITLE
Upper bound cuDNN compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ CEnum = "0.4"
 CUDA = "4, 5"
 DataStructures = "0.18"
 DocStringExtensions = "0.8, 0.9"
-cuDNN = "1.1"
+cuDNN = "~1.1, ~1.2, =1.3.0"
 julia = "1.9"
 
 [extensions]


### PR DESCRIPTION
Fixes #37 together with https://github.com/JuliaRegistries/General/pull/104940.

There is intentionally no version bump in this PR. The real work is done by the retroactive upper bounding in the registry PR and given that there would be no point releasing a new version only with this compat change. But we still want to apply the changes here too so they are not reversed when a new version is eventually released.
