### PR TITLE
Logging level

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ONNXRunTime"
 uuid = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ output_array = GetTensorMutableData(api, output_tensor);
 * [ONNX.jl](https://github.com/FluxML/ONNX.jl)
 * [ONNXNaiveNASflux.jl](https://github.com/DrChainsaw/ONNXNaiveNASflux.jl)
 
+# Complements
+
+* [ONNXLowLevel.jl](https://github.com/GunnarFarneback/ONNXLowLevel.jl) cannot
+  run inference but can be used to investigate, create, or manipulate ONNX
+  files.
+
 # Breaking Changes in version 0.4.
 
 * Support for CUDA.jl is changed from version 3 to versions 4 and 5.


### PR DESCRIPTION
Add support for setting the logging level in `load_inference`.

Additionally extends the `load_inference` docstring and adds a link to the new ONNXLowLevel package.
