### PR TITLE
Update onnxruntime to 1.20.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.9'
           - '1'
           - 'nightly'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - '1.10'
           - '1'
           - 'nightly'
         os:

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,15 +1,16 @@
 [[onnxruntime_cpu]]
 arch = "x86_64"
-git-tree-sha1 = "8537307691275bdf5dd2c646e3775649643ccecf"
+git-tree-sha1 = "7a5a70a99ed5931ff451b6e70a29944cd3d4b54d"
 lazy = true
 os = "windows"
 
     [[onnxruntime_cpu.download]]
-    sha256 = "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+    sha256 = "78d447051e48bd2e1e778bba378bec4ece11191c9e538cf7b2c4a4565e8f5581"
     url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-win-x64-1.20.1.tgz"
+
 [[onnxruntime_cpu]]
 arch = "x86_64"
-git-tree-sha1 = "f449f6728afcfc4e1d18a33685f337de62732011"
+git-tree-sha1 = "7a5a70a99ed5931ff451b6e70a29944cd3d4b54d"
 lazy = true
 libc = "glibc"
 os = "linux"
@@ -17,18 +18,20 @@ os = "linux"
     [[onnxruntime_cpu.download]]
     sha256 = "67db4dc1561f1e3fd42e619575c82c601ef89849afc7ea85a003abbac1a1a105"
     url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-linux-x64-1.20.1.tgz"
+
 [[onnxruntime_cpu]]
 arch = "x86_64"
-git-tree-sha1 = "e83647aba10d99e20321ad123cb92974fee357dc"
+git-tree-sha1 = "4652621efdd6d8c61987734403a7e7e1fff19079"
 lazy = true
 os = "macos"
 
     [[onnxruntime_cpu.download]]
     sha256 = "da4349e01a7e997f5034563183c7183d069caadc1d95f499b560961787813efd"
     url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-universal2-1.20.1.tgz"
+
 [[onnxruntime_cpu]]
 arch = "aarch64"
-git-tree-sha1 = "3aaa741ff710a21c23370cda7d967939dfc82e6a"
+git-tree-sha1 = "9f203a6745ce1e17f0afb8528688b95d1791d851"
 lazy = true
 os = "macos"
 
@@ -38,16 +41,17 @@ os = "macos"
 
 [[onnxruntime_gpu]]
 arch = "x86_64"
-git-tree-sha1 = "09c70e5af145d9c84cada2cbda13ff07e18a1dbc"
+git-tree-sha1 = "478f998b8d737218ef0cc06d26e91288d1e72f3b"
 lazy = true
 os = "windows"
 
     [[onnxruntime_gpu.download]]
     sha256 = "3e9658d4aa7c21b3f5cbb5a7ce0356184f3c183c317b52f9cfff23a3f079634e"
     url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-win-x64-gpu-1.20.1.zip"
+
 [[onnxruntime_gpu]]
 arch = "x86_64"
-git-tree-sha1 = "a6b97c24aaf0f98fb899dc4cb4e076fb4e3bf2a8"
+git-tree-sha1 = "478f998b8d737218ef0cc06d26e91288d1e72f3b"
 lazy = true
 libc = "glibc"
 os = "linux"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,13 +1,12 @@
 [[onnxruntime_cpu]]
 arch = "x86_64"
-git-tree-sha1 = "7a5a70a99ed5931ff451b6e70a29944cd3d4b54d"
+git-tree-sha1 = "03ca4920f8c66efacaa58cdb30ee6da83b7a40e0"
 lazy = true
 os = "windows"
 
     [[onnxruntime_cpu.download]]
-    sha256 = "78d447051e48bd2e1e778bba378bec4ece11191c9e538cf7b2c4a4565e8f5581"
-    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-win-x64-1.20.1.tgz"
-
+    sha256 = "0dbe0bb59e2c000d9b331d1dfd2a61a7af2cfea1d5391d369fcd8d3ea504b3b8"
+    url = "https://github.com/jw3126/ONNXRunTimeArtifacts/releases/download/v1.20.1-rc1/onnxruntime-win-x64-1.20.1.tgz"
 [[onnxruntime_cpu]]
 arch = "x86_64"
 git-tree-sha1 = "7a5a70a99ed5931ff451b6e70a29944cd3d4b54d"
@@ -18,7 +17,6 @@ os = "linux"
     [[onnxruntime_cpu.download]]
     sha256 = "67db4dc1561f1e3fd42e619575c82c601ef89849afc7ea85a003abbac1a1a105"
     url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-linux-x64-1.20.1.tgz"
-
 [[onnxruntime_cpu]]
 arch = "x86_64"
 git-tree-sha1 = "4652621efdd6d8c61987734403a7e7e1fff19079"
@@ -28,27 +26,25 @@ os = "macos"
     [[onnxruntime_cpu.download]]
     sha256 = "da4349e01a7e997f5034563183c7183d069caadc1d95f499b560961787813efd"
     url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-universal2-1.20.1.tgz"
-
 [[onnxruntime_cpu]]
 arch = "aarch64"
-git-tree-sha1 = "9f203a6745ce1e17f0afb8528688b95d1791d851"
+git-tree-sha1 = "4652621efdd6d8c61987734403a7e7e1fff19079"
 lazy = true
 os = "macos"
 
     [[onnxruntime_cpu.download]]
-    sha256 = "b678fc3c2354c771fea4fba420edeccfba205140088334df801e7fc40e83a57a"
-    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-arm64-1.20.1.tgz"
+    sha256 = "da4349e01a7e997f5034563183c7183d069caadc1d95f499b560961787813efd"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-universal2-1.20.1.tgz"
 
 [[onnxruntime_gpu]]
 arch = "x86_64"
-git-tree-sha1 = "478f998b8d737218ef0cc06d26e91288d1e72f3b"
+git-tree-sha1 = "9740e9c731f3aeaa8ea93e25a787e91cf8f64bd7"
 lazy = true
 os = "windows"
 
     [[onnxruntime_gpu.download]]
-    sha256 = "3e9658d4aa7c21b3f5cbb5a7ce0356184f3c183c317b52f9cfff23a3f079634e"
-    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-win-x64-gpu-1.20.1.zip"
-
+    sha256 = "622828adb36268ce58d69eade91827d92354388f6e6a3be777fffe54acab84a2"
+    url = "https://github.com/jw3126/ONNXRunTimeArtifacts/releases/download/v1.20.1-rc1/onnxruntime-win-x64-gpu-1.20.1.tgz"
 [[onnxruntime_gpu]]
 arch = "x86_64"
 git-tree-sha1 = "478f998b8d737218ef0cc06d26e91288d1e72f3b"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,57 +1,57 @@
 [[onnxruntime_cpu]]
 arch = "x86_64"
-git-tree-sha1 = "ee0b3b47cb5c295d8e2df9b704d472fa827fbb59"
+git-tree-sha1 = "8537307691275bdf5dd2c646e3775649643ccecf"
 lazy = true
 os = "windows"
 
     [[onnxruntime_cpu.download]]
-    sha256 = "f132ee57ab970c496f08e344bef60f03d3cf61475c93628feef2a1ac94e88aa1"
-    url = "https://github.com/jw3126/ONNXRunTimeArtifacts/releases/download/v1.15.1-rc1/onnxruntime-win-x64-1.15.1.tgz"
+    sha256 = "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-win-x64-1.20.1.tgz"
 [[onnxruntime_cpu]]
 arch = "x86_64"
-git-tree-sha1 = "fe904e447d592a9cf7aaac236a58a94f91f761d1"
+git-tree-sha1 = "f449f6728afcfc4e1d18a33685f337de62732011"
 lazy = true
 libc = "glibc"
 os = "linux"
 
     [[onnxruntime_cpu.download]]
-    sha256 = "5492f9065f87538a286fb04c8542e9ff7950abb2ea6f8c24993a940006787d87"
-    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.15.1/onnxruntime-linux-x64-1.15.1.tgz"
+    sha256 = "67db4dc1561f1e3fd42e619575c82c601ef89849afc7ea85a003abbac1a1a105"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-linux-x64-1.20.1.tgz"
 [[onnxruntime_cpu]]
 arch = "x86_64"
-git-tree-sha1 = "fcb94c1a37609b80bf69b143bfcd60b0ff1fbef1"
+git-tree-sha1 = "e83647aba10d99e20321ad123cb92974fee357dc"
 lazy = true
 os = "macos"
 
     [[onnxruntime_cpu.download]]
-    sha256 = "ecb7651c216fe6ffaf4c578e135d98341bc5bc944c5dc6b725ef85b0d7747be0"
-    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.15.1/onnxruntime-osx-universal2-1.15.1.tgz"
+    sha256 = "da4349e01a7e997f5034563183c7183d069caadc1d95f499b560961787813efd"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-universal2-1.20.1.tgz"
 [[onnxruntime_cpu]]
 arch = "aarch64"
-git-tree-sha1 = "fcb94c1a37609b80bf69b143bfcd60b0ff1fbef1"
+git-tree-sha1 = "3aaa741ff710a21c23370cda7d967939dfc82e6a"
 lazy = true
 os = "macos"
 
     [[onnxruntime_cpu.download]]
-    sha256 = "ecb7651c216fe6ffaf4c578e135d98341bc5bc944c5dc6b725ef85b0d7747be0"
-    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.15.1/onnxruntime-osx-universal2-1.15.1.tgz"
+    sha256 = "b678fc3c2354c771fea4fba420edeccfba205140088334df801e7fc40e83a57a"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-arm64-1.20.1.tgz"
 
 [[onnxruntime_gpu]]
 arch = "x86_64"
-git-tree-sha1 = "68acc458450c6cff16f55c8cedba213f1eeeb678"
+git-tree-sha1 = "09c70e5af145d9c84cada2cbda13ff07e18a1dbc"
 lazy = true
 os = "windows"
 
     [[onnxruntime_gpu.download]]
-    sha256 = "94aea5b7ec2ffeecca8225816116922cab7ce0f4f2a5516c28e241cdbf4c04db"
-    url = "https://github.com/jw3126/ONNXRunTimeArtifacts/releases/download/v1.15.1-rc1/onnxruntime-win-x64-gpu-1.15.1.tgz"
+    sha256 = "3e9658d4aa7c21b3f5cbb5a7ce0356184f3c183c317b52f9cfff23a3f079634e"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-win-x64-gpu-1.20.1.zip"
 [[onnxruntime_gpu]]
 arch = "x86_64"
-git-tree-sha1 = "d7e3cdf6598724d24e8f854817c6e71a1f6fe57e"
+git-tree-sha1 = "a6b97c24aaf0f98fb899dc4cb4e076fb4e3bf2a8"
 lazy = true
 libc = "glibc"
 os = "linux"
 
     [[onnxruntime_gpu.download]]
-    sha256 = "eab891393025edd5818d1aa26a42860e5739fcc49e3ca3f876110ec8736fe7f1"
-    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.15.1/onnxruntime-linux-x64-gpu-1.15.1.tgz"
+    sha256 = "6bfb87c6ebe55367a94509b8ef062239e188dccf8d5caac8d6909b2344893bf0"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-linux-x64-gpu-1.20.1.tgz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -28,13 +28,13 @@ os = "macos"
     url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-universal2-1.20.1.tgz"
 [[onnxruntime_cpu]]
 arch = "aarch64"
-git-tree-sha1 = "4652621efdd6d8c61987734403a7e7e1fff19079"
+git-tree-sha1 = "9f203a6745ce1e17f0afb8528688b95d1791d851"
 lazy = true
 os = "macos"
 
     [[onnxruntime_cpu.download]]
-    sha256 = "da4349e01a7e997f5034563183c7183d069caadc1d95f499b560961787813efd"
-    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-universal2-1.20.1.tgz"
+    sha256 = "b678fc3c2354c771fea4fba420edeccfba205140088334df801e7fc40e83a57a"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-arm64-1.20.1.tgz"
 
 [[onnxruntime_gpu]]
 arch = "x86_64"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ONNXRunTime"
 uuid = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ CEnum = "0.4, 0.5"
 CUDA = "4, 5"
 DataStructures = "0.18"
 DocStringExtensions = "0.8, 0.9"
-cuDNN = "~1.1, ~1.2, =1.3.0"
+cuDNN = "~1.1, ~1.2, ~1.3"
 julia = "1.9"
 
 [extensions]

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ CEnum = "0.4, 0.5"
 CUDA = "4, 5"
 DataStructures = "0.18"
 DocStringExtensions = "0.8, 0.9"
-cuDNN = "~1.1, ~1.2, ~1.3"
+cuDNN = "~1.3, ~1.4"
 julia = "1.9"
 
 [extensions]

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ CUDA = "4, 5"
 DataStructures = "0.18"
 DocStringExtensions = "0.8, 0.9"
 cuDNN = "~1.3, ~1.4"
-julia = "1.10"
+julia = "1.9"
 
 [extensions]
 CUDAExt = ["CUDA", "cuDNN"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ CUDA = "4, 5"
 DataStructures = "0.18"
 DocStringExtensions = "0.8, 0.9"
 cuDNN = "~1.3, ~1.4"
-julia = "1.9"
+julia = "1.10"
 
 [extensions]
 CUDAExt = ["CUDA", "cuDNN"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Dict{String, Matrix{Float32}} with 1 entry:
 ```
 
 For GPU usage the CUDA and cuDNN packages are required and the CUDA
-runtime needs to be set to 11.8 or a later 11.x version. To set this
+runtime needs to be set to 12.0 or a later 12.x version. To set this
 up, do
 
 ```julia
@@ -38,7 +38,7 @@ pkg> add CUDA cuDNN
 
 julia> import CUDA
 
-julia> CUDA.set_runtime_version!(v"11.8")
+julia> CUDA.set_runtime_version!(v"12.0")
 ```
 
 Then GPU inference is simply
@@ -109,14 +109,14 @@ and import CUDA and cuDNN. Additionally a supported CUDA runtime
 version needs to be used, which can be somewhat tricky to set up for
 the tests.
 
-First some background. What `CUDA.set_runtime_version!(v"11.8")`
+First some background. What `CUDA.set_runtime_version!(v"12.0")`
 effectively does is to
 
 1. Add a `LocalPreferences.toml` file containing
 
 ```
 [CUDA_Runtime_jll]
-version = "11.8"
+version = "12.0"
 ```
 
 2. In `Project.toml`, add

--- a/src/versions.jl
+++ b/src/versions.jl
@@ -16,6 +16,6 @@
 #   is *not* accepted. Presumably CUDA runtime follows semantic
 #   versioning so this can automatically be set to the next major
 #   version.
-const onnxruntime_version = v"1.15.1"
-const cuda_runtime_supported_version = v"11.8"
+const onnxruntime_version = v"1.20.1"
+const cuda_runtime_supported_version = v"12.0"
 const cuda_runtime_upper_bound = VersionNumber(cuda_runtime_supported_version.major + 1)

--- a/test/LocalPreferences.toml
+++ b/test/LocalPreferences.toml
@@ -1,2 +1,2 @@
 [CUDA_Runtime_jll]
-version = "11.8"
+version = "12.0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,7 +5,7 @@ cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
 CUDA = "5"
-cuDNN = "1.2"
+cuDNN = "1.4"
 
 [extras]
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,7 +5,7 @@ cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
 CUDA = "5"
-cuDNN = "1.4"
+cuDNN = "1.3"
 
 [extras]
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"


### PR DESCRIPTION
First of all, thank you for this amazing package!!

I've hit some issues with the outdated binary we were using (I needed IR v10), so I've updated the repo accordingly. 
In addition, I've also changed the macos aarch64 to the correct binary - they now produce a native one.

**TODO list**
[x] Update all artifacts links to 1.20.1, update SHA1 and SHA256 values
[x] Update src/versions.jl to Cuda 12.0 (as per the announcement of onnxruntime 1.19: "Default GPU packages use CUDA 12.x and Cudnn 9.x (previously CUDA 11.x/CuDNN 8.x) CUDA 11.x/CuDNN 8.x packages are moved to the aiinfra VS feed.")
[x] Update the reference to Cuda 11.8 on the README page
[x] Ran tests (locally) -- all passed
[x] Verified that the package loads the model with IR10 and all works
 