### PR TITLE
Stop using Base.get_extension.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,33 +20,24 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - run: |

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ONNXRunTime"
 uuid = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.3.1"
+version = "1.3.2"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -1,11 +1,15 @@
 module CUDAExt
+import ONNXRunTime
+import CUDA
 
-# These functions are only defined for diagnostic purposes. Otherwise
+# These calls are only being made for diagnostic purposes. Otherwise
 # the CUDA extension only relies on the CUDA and cuDNN dependencies to
 # have loaded the libraries needed by ONNXRunTime's CUDA execution
 # provider.
-import CUDA
-cuda_functional() = CUDA.functional()
-cuda_runtime_version() = CUDA.runtime_version()
+function __init__()
+    ONNXRunTime.cuda_is_loaded[] = true
+    ONNXRunTime.cuda_is_functional[] = CUDA.functional()
+    ONNXRunTime.cuda_runtime_version[] = CUDA.runtime_version()
+end
 
 end

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -15,10 +15,16 @@ using .CAPI
 using .CAPI: juliatype, EXECUTION_PROVIDERS
 export InferenceSession, load_inference, release
 
+# Interaction point with the CUDA extension. These values will be
+# updated by the extension when it is loaded.
+const cuda_is_loaded = Ref(false)
+const cuda_is_functional = Ref(false)
+const cuda_runtime_version = Ref(v"0.0.0")
+
 """
     $TYPEDEF
 
-Represents an infernence session. Should only be created by calling [`load_inference`](@ref).
+Represents an inference session. Should only be created by calling [`load_inference`](@ref).
 """
 struct InferenceSession
     api::OrtApi
@@ -99,20 +105,18 @@ function load_inference(path::AbstractString; execution_provider::Symbol=:cpu,
         end
         session_options = CreateSessionOptions(api)
     elseif execution_provider === :cuda
-        CUDAExt = Base.get_extension(@__MODULE__, :CUDAExt)
-        if isnothing(CUDAExt)
+        if !cuda_is_loaded[]
             error("""
             The $(repr(execution_provider)) execution provider requires the CUDA.jl and cuDNN.jl packages to be available. Try adding `import CUDA, cuDNN` to your code.
             """)
-        elseif !getfield(CUDAExt, :cuda_functional)()
+        elseif !cuda_is_functional[]
             error("""
             The $(repr(execution_provider)) execution provider requires CUDA to be functional. See `CUDA.functional`.
             """)
         else
-            cuda_runtime_version = getfield(CUDAExt, :cuda_runtime_version)()
-            if !(cuda_runtime_supported_version <= cuda_runtime_version < cuda_runtime_upper_bound)
+            if !(cuda_runtime_supported_version <= cuda_runtime_version[] < cuda_runtime_upper_bound)
                 error("""
-                Found CUDA runtime version $(cuda_runtime_version). The $(repr(execution_provider)) execution provider requires a CUDA runtime version of at least $(cuda_runtime_supported_version) but less than $(cuda_runtime_upper_bound). See `CUDA.set_runtime_version!` and the package README.
+                Found CUDA runtime version $(cuda_runtime_version[]). The $(repr(execution_provider)) execution provider requires a CUDA runtime version of at least $(cuda_runtime_supported_version) but less than $(cuda_runtime_upper_bound). See `CUDA.set_runtime_version!` and the package README.
                 """)
             end
         end


### PR DESCRIPTION
According to https://github.com/JuliaLang/julia/pull/59593 it's a bad idea to use `Base.get_extension` and this alternative arguably looks nicer anyway.
