### PR TITLE
Support CUDA 6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,24 +1,24 @@
 name = "ONNXRunTime"
 uuid = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.3.2"
+version = "1.3.3"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 ArgCheck = "2"
 CEnum = "0.4, 0.5"
-CUDA = "4, 5"
-DataStructures = "0.18, 0.19"
+CUDA = "4, 5, 6"
 DocStringExtensions = "0.8, 0.9"
-cuDNN = "~1.3, ~1.4"
+OrderedCollections = "1, 2"
+cuDNN = "~1.3, ~1.4, 6"
 julia = "1.9"
 
 [extensions]

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -1,6 +1,6 @@
 using ArgCheck
 using LazyArtifacts
-using DataStructures: OrderedDict
+using OrderedCollections: OrderedDict
 using DocStringExtensions
 import CEnum
 ################################################################################

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,9 +3,5 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
-[compat]
-CUDA = "5"
-cuDNN = "1.3"
-
 [extras]
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/test/test_cuda_extension.jl
+++ b/test/test_cuda_extension.jl
@@ -1,9 +1,10 @@
 # This file is neither included from `runtests.jl` nor run in CI.
 #
-# Run it with `julia tests/test_cuda_extension.jl`. This requires that
+# Run it with `julia test/test_cuda_extension.jl`. This requires that
 # Julia is installed with juliaup and will involve downloading of a
-# lot of big artifacts. The output will contain lots of error messages
-# from caught errors; what matters is that all testsets pass.
+# lot of big artifacts and a couple of julia versions. The output will
+# contain lots of error messages from caught errors; what matters is
+# that all testsets pass.
 
 using Test
 
@@ -17,7 +18,11 @@ if !juliaup_found
     error("`juliaup` needs to be installed for the CUDA extension tests")
 end
 
-wait(run(`juliaup add 1.9`, wait = false))
+const tested_julia_versions = ["1.9", "1.10", "1.11", "1.12"]
+
+for version in tested_julia_versions
+    run(`juliaup add $version`)
+end
 
 package_path = dirname(@__DIR__)
 onnx_path = joinpath(@__DIR__, "data", "copy2d.onnx")
@@ -38,92 +43,70 @@ function with_environment(f::Function; cuda_runtime_version)
     end
 end
 
-@testset "Julia 1.9 CUDA 3" begin
-    with_environment(cuda_runtime_version = "11.8") do env
-        install_script = """
-                         using Pkg
-                         Pkg.develop(path = "$(package_path)")
-                         Pkg.add(name = "CUDA", version = "3")
-                         """
-        # CUDA 3 is not possible to install together with ONNXRunTime
-        # on Julia 1.9 due to Compat requirements.
-        @test_throws ProcessFailedException run(`julia +1.9 --project=$(env) -e "$(install_script)"`)
-    end
-end
+@testset "Julia $(julia_version) CUDA.jl $(cuda_version) CUDA runtime 12" for julia_version in tested_julia_versions, cuda_version in 4:6
+    # CUDA 6 is only compatible with Julia 1.10 and later.
+    julia_version == "1.9" && cuda_version == 6 && continue
+    # CUDA 4 is not installable on Julia 1.10 and later.
+    VersionNumber(julia_version) > v"1.9" && cuda_version < 5 && continue
 
-@testset "Julia 1.9 CUDA.jl $(cuda_version) CUDA runtime 11.8" for cuda_version in (4, 5)
-    with_environment(cuda_runtime_version = "11.8") do env
+    with_environment(cuda_runtime_version = "12") do env
         install_script = """
                          using Pkg
                          Pkg.develop(path = "$(package_path)")
                          Pkg.add(name = "CUDA", version = "$(cuda_version)")
                          Pkg.add(name = "cuDNN")
                          """
-        @test success(run(`julia +1.9 --project=$(env) -e "$(install_script)"`))
+        @test success(run(`julia +$(julia_version) --project=$(env) -e "$(install_script)"`))
         # Correct dependencies for :cuda.
         test_script = """
                       using ONNXRunTime, CUDA, cuDNN
                       load_inference("$(onnx_path)", execution_provider = :cuda)
                       """
-        @test success(run(`julia +1.9 --project=$(env) -e "$(test_script)"`))
+        @test success(run(`julia +$(julia_version) --project=$(env) -e "$(test_script)"`))
         # Neither CUDA nor cuDNN loaded.
         test_script = """
                       using ONNXRunTime
                       load_inference("$(onnx_path)", execution_provider = :cuda)
                       """
-        @test_throws ProcessFailedException run(`julia +1.9 --project=$(env) -e "$(test_script)"`)
+        @test_throws ProcessFailedException run(`julia +$(julia_version) --project=$(env) -e "$(test_script)"`)
         # Neither CUDA nor cuDNN loaded but running on CPU, so it's fine.
         test_script = """
                       using ONNXRunTime
                       load_inference("$(onnx_path)", execution_provider = :cpu)
                       """
-        @test success(run(`julia +1.9 --project=$(env) -e "$(test_script)"`))
+        @test success(run(`julia +$(julia_version) --project=$(env) -e "$(test_script)"`))
         # CUDA not loaded. Well, cuDNN pulls in CUDA so this passes anyway.
+        # Update: It does on Julia 1.9 but not later.
         test_script = """
                       using ONNXRunTime
                       using cuDNN
                       load_inference("$(onnx_path)", execution_provider = :cuda)
                       """
-        @test success(run(`julia +1.9 --project=$(env) -e "$(test_script)"`))
+        if VersionNumber(julia_version) <= v"1.9"
+            @test success(run(`julia +$(julia_version) --project=$(env) -e "$(test_script)"`))
+        else
+            @test_throws ProcessFailedException run(`julia +$(julia_version) --project=$(env) -e "$(test_script)"`)
+        end
         # CUDA not loaded but running on CPU, so it's fine.
         test_script = """
                       using ONNXRunTime
                       using cuDNN
                       load_inference("$(onnx_path)", execution_provider = :cpu)
                       """
-        @test success(run(`julia +1.9 --project=$(env) -e "$(test_script)"`))
+        @test success(run(`julia +$(julia_version) --project=$(env) -e "$(test_script)"`))
         # cuDNN not loaded.
         test_script = """
                       using ONNXRunTime
                       using CUDA
                       load_inference("$(onnx_path)", execution_provider = :cuda)
                       """
-        @test_throws ProcessFailedException run(`julia +1.9 --project=$(env) -e "$(test_script)"`)
+        @test_throws ProcessFailedException run(`julia +$(julia_version) --project=$(env) -e "$(test_script)"`)
         # cuDNN not loaded but running on CPU, so it's fine.
         test_script = """
                       using ONNXRunTime
                       using CUDA
                       load_inference("$(onnx_path)", execution_provider = :cpu)
                       """
-        @test success(run(`julia +1.9 --project=$(env) -e "$(test_script)"`))
-    end
-end
-
-@testset "Julia 1.9 CUDA.jl $(cuda_version) CUDA runtime $(cuda_runtime_version)" for cuda_version in (4, 5), cuda_runtime_version in ("11.6", "12.1")
-    with_environment(; cuda_runtime_version) do env
-        install_script = """
-                         using Pkg
-                         Pkg.develop(path = "$(package_path)")
-                         Pkg.add(name = "CUDA", version = "$(cuda_version)")
-                         Pkg.add(name = "cuDNN")
-                         """
-        @test success(run(`julia +1.9 --project=$(env) -e "$(install_script)"`))
-        # Correct dependencies for :cuda but fails due to bad version
-        # of CUDA runtime.
-        test_script = """
-                      using ONNXRunTime, CUDA, cuDNN
-                      load_inference("$(onnx_path)", execution_provider = :cuda)
-                      """
-        @test_throws ProcessFailedException run(`julia +1.9 --project=$(env) -e "$(test_script)"`)
+        @test success(run(`julia +$(julia_version) --project=$(env) -e "$(test_script)"`))
     end
 end


### PR DESCRIPTION
* Loosen CUDA and cuDNN compat to allow version 6.
* Replace DataStructures dependency with OrderedCollections.

Allowing CUDA/cuDNN v6 seems to just work. I've tested it with the revised `test/test_cuda_extension.jl` and with a private package at my company.

The reason to replace DataStructures with OrderedCollections is that either is only needed for `OrderedDict` and DataStructures just reexports OrderedCollections anyway. Thus there is no reason to impose the heavier dependency on downstream users.

Longer term the CUDA weak dependency should probably be replaced with CUDACore and the specific CUDA sublibraries that are actually linked from ONNXRunTime, but that will require more thorough investigations and possibly reducing the Julia and CUDA compats.