### PR TITLE
Fix bug with reversedims on Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ONNXRunTime"
 uuid = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.3.3"
+version = "1.3.4"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/ONNXRunTime.jl
+++ b/src/ONNXRunTime.jl
@@ -6,6 +6,9 @@ end
 function reversedims(arr)
     permutedims(arr, _perm(arr))
 end
+function reversedims(arr::AbstractArray{T,0}) where {T}
+    return arr
+end
 function reversedims_lazy(arr)
     PermutedDimsArray(arr, _perm(arr))
 end

--- a/test/test_highlevel.jl
+++ b/test/test_highlevel.jl
@@ -160,6 +160,17 @@ using ONNXRunTime: juliatype
         @test_throws ErrorException y = model((;input))
         @test_throws "Session has been released and can no longer be called." y = model((;input))
     end
+    @testset "Miscellaneous functions" begin
+        x = fill(3)
+        y = [1, 2, 3]
+        z = [1 2 3; 4 5 6]
+        @test ORT.reversedims(x) == x
+        @test ORT.reversedims(y) == y
+        @test ORT.reversedims(z) == z'
+        @test ORT.reversedims_lazy(x) == x
+        @test ORT.reversedims_lazy(y) == y
+        @test ORT.reversedims_lazy(z) == z'
+    end
 end
 
 


### PR DESCRIPTION
Due to issues in `permutedims` on Julia 1.10, `reversedims` throws when called with a scalar array, i.e., an `AbstractArray{T,0}`. This PR fixes that problem.

This closes https://github.com/jw3126/ONNXRunTime.jl/issues/46.