### PR TITLE
Add aarch64-linux CPU artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -28,6 +28,16 @@ os = "macos"
     url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-osx-universal2-1.20.1.tgz"
 [[onnxruntime_cpu]]
 arch = "aarch64"
+git-tree-sha1 = "00edaa23e74caa32f34a8dfbf08101123627e8c3"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[onnxruntime_cpu.download]]
+    sha256 = "ae4fedbdc8c18d688c01306b4b50c63de3445cdf2dbd720e01a2fa3810b8106a"
+    url = "https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-linux-aarch64-1.20.1.tgz"
+[[onnxruntime_cpu]]
+arch = "aarch64"
 git-tree-sha1 = "9f203a6745ce1e17f0afb8528688b95d1791d851"
 lazy = true
 os = "macos"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ONNXRunTime"
 uuid = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.3.3"
+version = "1.3.4"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"


### PR DESCRIPTION
Adds an `onnxruntime_cpu` entry for **aarch64 Linux (glibc)**, pointing at the official Microsoft binary from the same upstream release the existing entries already use: [`onnxruntime-linux-aarch64-1.20.1.tgz`](https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-linux-aarch64-1.20.1.tgz).

## Motivation
On aarch64 Linux, `load_inference(...; execution_provider=:cpu)` currently fails with

```
Unsupported execution_provider = :cpu for
this architectur.
```

because `Artifacts.toml` covers x86_64 (Windows/Linux/macOS) and aarch64-macOS, but not aarch64-Linux. This platform is increasingly common: Docker/podman containers on Apple Silicon Macs, arm64 CI runners, and arm64 cloud instances. We hit it building a multi-arch container for [FUSE](https://github.com/ProjectTorreyPines/FUSE.jl) (FUsion Synthesis Engine), whose plasma-stability actor does ONNX inference through this package.

## Verification
- `artifact_hash("onnxruntime_cpu", ...; platform=Platform("aarch64","linux"; libc="glibc"))` resolves to the new entry; all existing platforms resolve unchanged.
- `ensure_artifact_installed` for that platform downloads and validates the artifact end to end (sha256 + git-tree-sha1 both verified by Pkg).
- The extracted `lib/libonnxruntime.so.1.20.1` is `ELF 64-bit LSB shared object, ARM aarch64`.

No code changes needed — `make_lib!` only errored because `artifact_hash` returned `nothing` for the platform. Runtime testing on real aarch64-Linux hardware will come from our container CI (GitHub `ubuntu-24.04-arm` runners); happy to report back results here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)